### PR TITLE
Fix serialization of tags in a mod package context when they are firs…

### DIFF
--- a/TagTool/Cache/ModPackages/GameCacheModPackage.cs
+++ b/TagTool/Cache/ModPackages/GameCacheModPackage.cs
@@ -72,7 +72,8 @@ namespace TagTool.Cache
 
         public override void Serialize(Stream stream, CachedTag instance, object definition)
         {
-            Serializer.Serialize(CreateTagSerializationContext(stream, instance), definition);
+            var modCachedTag = TagCache.GetTag(instance.Index) as CachedTagHaloOnline;
+            Serializer.Serialize(CreateTagSerializationContext(stream, modCachedTag), definition);
         }
 
         private ISerializationContext CreateTagSerializationContext(Stream stream, CachedTag instance)

--- a/TagTool/Commands/Scenarios/GenerateCanvasCommand.cs
+++ b/TagTool/Commands/Scenarios/GenerateCanvasCommand.cs
@@ -102,7 +102,7 @@ namespace TagTool.Commands.Scenarios
         private bool AskForParameterInput(GeneratorParameters parameters)
         {
             if (!RequestBoundedInput("Enter desired scenario tagname (e.g. levels\\eldewrito\\canvas\\canvas):",
-                out parameters.ScenarioPath))
+                out parameters.ScenarioPath, forceLowercase: true))
                 return false;
 
             var fullName = $"{parameters.ScenarioPath}.scnr";
@@ -118,15 +118,15 @@ namespace TagTool.Commands.Scenarios
             }
 
             if (!RequestBoundedInput("Enter the map display name (<16 characters):",
-                out parameters.MapName, 15))
+                out parameters.MapName, 15, forceLowercase: false))
                 return false;
 
             if (!RequestBoundedInput("Enter the map description: (<128 characters)",
-                out parameters.MapDescription, 127))
+                out parameters.MapDescription, 127, forceLowercase: false))
                 return false;
 
             if (!RequestBoundedInput("Enter the map author (<16 characters):",
-                out parameters.MapDescription, 15))
+                out parameters.MapAuthor, 15, forceLowercase: false))
                 return false;
 
             if (!RequestBoundedInput("Enter a mapID (integer) between 7000 and 65535:",
@@ -151,10 +151,12 @@ namespace TagTool.Commands.Scenarios
             return true;
         }
 
-        private bool RequestBoundedInput(string prompt, out string value, int upperBound = 0, int lowerBound = 0)
+        private bool RequestBoundedInput(string prompt, out string value, int upperBound = 0, int lowerBound = 0, bool forceLowercase = true)
         {
             Console.WriteLine(prompt);
-            string input = CommandRunner.ApplyUserVars(@Console.ReadLine().ToLower(), IgnoreArgumentVariables);
+            string input = CommandRunner.ApplyUserVars(
+                forceLowercase ? @Console.ReadLine().ToLower() : @Console.ReadLine(),
+                IgnoreArgumentVariables);
 
             if (InputIsValid(input, upperBound, lowerBound))
             {


### PR DESCRIPTION
…t accessed from the base cache from "indirect" ways

I tested this with aa mod that does lots of direct tag additions, changes, porting, ect, I don't see any issue, but someone should double check this